### PR TITLE
Remove export default to fix issue in Nodejs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm i overfast-api-client
 ## Usage
 
 ```typescript
-import OverfastClient from "overfast-api-client";
+import { OverfastClient } from "overfast-api-client";
 ```
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "overfast-api-client",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OverFast API Client is a TypeScript package that allows users to interact with the OverFast API, an unofficial API for Overwatch 2. It simplifies the process of fetching data about heroes, game modes, maps and player statistics from the OverFast API. It is easy to install and use, and supports both promises and callbacks.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export const BlizzardServerError = BlizzardServerErr;
 export type NEW_HEROES_KEYS<T extends string | number | symbol> = T extends HEROES_KEYS ? HEROES_KEYS : T | HEROES_KEYS;
 
 
-export default class OverfastClient<HEROES extends string | number | symbol = HEROES_KEYS> {
+export class OverfastClient<HEROES extends string | number | symbol = HEROES_KEYS> {
 
   heroes;
   maps;
@@ -27,4 +27,3 @@ export default class OverfastClient<HEROES extends string | number | symbol = HE
     this.players = new Players<NEW_HEROES_KEYS<HEROES>>(url);
   }
 }
-


### PR DESCRIPTION
Remove default export to fix constructor error in NodeJs with type module.

Ref: https://github.com/Sipixer/overfast-api-client/issues/4


